### PR TITLE
Fixing syntax error in workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          # submodules: true # No longer needed with Hugo modules
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Fixed an issue in the workflow related to git submodules. Since I don't use them, I removed the offending line.