### PR TITLE
Fixing another syntax problem on the workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v4
-        with:
+        # with:
           # submodules: true # No longer needed with Hugo modules
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
I overlooked the fact that I had a `with:` with nothing under it.